### PR TITLE
Feature: inspect and mutate Forge config files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,3 +76,35 @@ jobs:
           body: |
             Staging build from `develop`.
             Commit: ${{ github.sha }}
+
+  publish:
+    name: Production release
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          prerelease: false
+          make_latest: true
+          files: artifacts/*


### PR DESCRIPTION
## Summary

- **`--get=<path>`** — read a single value or an entire section from a config file
- **`--type=<path>`** — print the type of a key (`bool`, `string`, `int`, `double`, `long`, `char`, `bool[]`, …, `subtree`)
- **`--set <path>=<value>`** — mutate one or more values and write the modified config to stdout
- All three flags use consistent dot notation (`section.subsection.key`)
- File path can be passed as a positional argument in addition to `--input-file-path`
- **`ConfigNode` enum refactor** — replaced `Vec<Box<dyn Node>>` with a typed enum, enabling type-safe traversal and mutation
- **GitHub Actions** — test job runs on every push and PR; staging pre-release on `develop` push; production release on `main` push (tag derived from `Cargo.toml`)
- **Branch protection** — merges to `develop` are blocked until the `Test` check passes
- **README** rewritten to reflect the actual CLI
- **Test coverage** expanded from 14 to 34 tests, covering `find`, `set`, `type_name`, all error variants, `ConfigFile` delegation, argument parsing, and round-trip fidelity against all three real example configs

## Test plan

- [x] All 34 unit tests pass
- [x] `--get` returns correct value for scalar, array, and section nodes
- [x] `--type` returns correct type name for all variants including `subtree` and array types
- [x] `--set` modifies the correct key and round-trip output is clean
- [x] Error cases (key not found, path into a leaf, conflicting flags) print to stderr and exit non-zero
- [x] Round-trip fidelity verified against Avaritia.cfg, aurora.cfg, serverutilities.cfg
- [ ] Staging release workflow fires on merge