### PR TITLE
Replace panics with real errors for malformed input and bad CLI args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "forge-config-edit"
-version = "0.1.0"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forge-config-edit"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]

--- a/src/config_file/config_file.rs
+++ b/src/config_file/config_file.rs
@@ -1,4 +1,5 @@
 use crate::config_file::value_tree::config_node::ConfigNode;
+use crate::config_file::value_tree::error::Error;
 use crate::config_file::value_tree::get_error::GetError;
 use crate::config_file::value_tree::set_error::SetError;
 use crate::config_file::value_tree::tree::Tree;
@@ -8,10 +9,10 @@ pub(crate) struct ConfigFile {
 }
 
 impl ConfigFile {
-    pub(crate) fn new(data: String) -> ConfigFile {
+    pub(crate) fn new(data: String) -> Result<ConfigFile, Error> {
         let mut buffer_lines = data.lines().map(|l| l.to_string());
-        let tree = Tree::new("root".to_string(), &mut buffer_lines).unwrap();
-        ConfigFile { tree }
+        let tree = Tree::new("root".to_string(), &mut buffer_lines)?;
+        Ok(ConfigFile { tree })
     }
 
     pub(crate) fn find<'a>(&'a self, path: &[&str]) -> Result<&'a ConfigNode, GetError> {
@@ -36,7 +37,7 @@ mod tests {
     #[test]
     fn test_config_file_find_returns_correct_value() {
         let input = "server {\n    B:enabled=true\n}".to_string();
-        let file = ConfigFile::new(input);
+        let file = ConfigFile::new(input).unwrap();
 
         let node = file.find(&["server", "enabled"]).unwrap();
         assert_eq!(node.value(), Some("true"));
@@ -45,7 +46,7 @@ mod tests {
     #[test]
     fn test_config_file_set_mutates_correctly() {
         let input = "server {\n    B:enabled=true\n}".to_string();
-        let mut file = ConfigFile::new(input);
+        let mut file = ConfigFile::new(input).unwrap();
 
         file.set(&["server", "enabled"], "false").unwrap();
 
@@ -54,16 +55,20 @@ mod tests {
     }
 }
 
-impl From<String> for ConfigFile {
-    fn from(data: String) -> ConfigFile {
-        ConfigFile::new(String::from(data))
+impl TryFrom<String> for ConfigFile {
+    type Error = Error;
+
+    fn try_from(data: String) -> Result<Self, Error> {
+        ConfigFile::new(data)
     }
 }
 
-impl From<Box<dyn Iterator<Item=String>>> for ConfigFile {
-    fn from(value: Box<dyn Iterator<Item=String>>) -> Self {
+impl TryFrom<Box<dyn Iterator<Item=String>>> for ConfigFile {
+    type Error = Error;
+
+    fn try_from(value: Box<dyn Iterator<Item=String>>) -> Result<Self, Error> {
         let mut value = value;
-        let tree = Tree::new("root".to_string(), &mut value).unwrap();
-        ConfigFile { tree }
+        let tree = Tree::new("root".to_string(), &mut value)?;
+        Ok(ConfigFile { tree })
     }
 }

--- a/src/config_file/value_tree/array.rs
+++ b/src/config_file/value_tree/array.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Formatter};
+use crate::config_file::value_tree::error::Error;
 use crate::config_file::value_tree::line_type::LineTypes;
 
 static DATATYPE_NAME_SEPARATOR: char = ':';
@@ -13,7 +14,7 @@ pub(crate) struct Array {
 }
 
 impl Array {
-    pub fn new(headline: String, lines: &mut dyn Iterator<Item=String>) -> Array {
+    pub fn new(headline: String, lines: &mut dyn Iterator<Item=String>) -> Result<Array, Error> {
         let mut values = Vec::<String>::new();
 
         let mut array_has_ended_flag = false;
@@ -33,12 +34,18 @@ impl Array {
             }
         }
 
-        let name_start = headline.chars().position(|c| c == DATATYPE_NAME_SEPARATOR).unwrap() + 1;
-        let name_end = headline.chars().position(|c| c == NAME_VALUE_SEPARATOR).unwrap();
+        let name_start = headline.chars().position(|c| c == DATATYPE_NAME_SEPARATOR)
+            .ok_or_else(|| Error::MalformedArrayHeader(headline.clone()))? + 1;
+        let name_end = headline.chars().position(|c| c == NAME_VALUE_SEPARATOR)
+            .ok_or_else(|| Error::MalformedArrayHeader(headline.clone()))?;
+        if name_end < name_start {
+            return Err(Error::MalformedArrayHeader(headline.clone()));
+        }
         let name = headline[name_start..name_end].trim().to_string();
-        let datatype = headline.chars().nth(0).unwrap().to_string();
+        let datatype = headline.chars().nth(0)
+            .ok_or_else(|| Error::MalformedArrayHeader(headline.clone()))?.to_string();
 
-        Array { name, datatype, values }
+        Ok(Array { name, datatype, values })
     }
 
     pub(crate) fn export(&self, s: &mut String, indent: usize) {

--- a/src/config_file/value_tree/error.rs
+++ b/src/config_file/value_tree/error.rs
@@ -1,5 +1,20 @@
+use std::fmt::{Display, Formatter};
+
 #[derive(Debug)]
 pub enum Error {
   LineNotParseable,
   UnknownLineType,
+  MissingSubtreeStart(String),
+  MalformedArrayHeader(String),
+}
+
+impl Display for Error {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Error::LineNotParseable => write!(f, "line could not be parsed"),
+      Error::UnknownLineType => write!(f, "unknown line type"),
+      Error::MissingSubtreeStart(line) => write!(f, "expected '{{' to start subtree in line: {line}"),
+      Error::MalformedArrayHeader(line) => write!(f, "malformed array header, expected format 'D:name <' in line: {line}"),
+    }
+  }
 }

--- a/src/config_file/value_tree/mod.rs
+++ b/src/config_file/value_tree/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod config_node;
 pub(crate) mod get_error;
 pub(crate) mod set_error;
 mod array;
-mod error;
+pub(crate) mod error;
 mod line_type;
 pub mod tree;
 mod value_pair;

--- a/src/config_file/value_tree/tree.rs
+++ b/src/config_file/value_tree/tree.rs
@@ -37,7 +37,8 @@ impl Tree {
           tree.tree_map.push(ConfigNode::ValuePair(ValuePair::try_new(raw.trim_start())?));
         },
         LineTypes::TreeStart => {
-          let name_end = line.chars().position(|c| c == SUBTREE_START_MARKER).unwrap();
+          let name_end = line.chars().position(|c| c == SUBTREE_START_MARKER)
+              .ok_or_else(|| Error::MissingSubtreeStart(line.to_string()))?;
           let name = line[..name_end].trim();
           tree.tree_map.push(ConfigNode::Tree(Box::new(Tree::new(name.to_string(), lines)?)));
         },
@@ -51,7 +52,7 @@ impl Tree {
           tree.tree_map.push(ConfigNode::Comment(Comment::new(raw.trim_start())));
         },
         LineTypes::ArrayStart => {
-          tree.tree_map.push(ConfigNode::Array(Array::new(line.to_string(), lines)));
+          tree.tree_map.push(ConfigNode::Array(Array::new(line.to_string(), lines)?));
         },
         LineTypes::ArrayEnd => {},
         LineTypes::Unknown => {

--- a/src/data_provider/implementations/file_provider.rs
+++ b/src/data_provider/implementations/file_provider.rs
@@ -1,6 +1,7 @@
 use crate::data_provider::data_provider::DataProvider;
 use std::fs::File;
-use std::io::{BufRead, Read};
+use std::io;
+use std::io::Read;
 
 pub(crate) struct FileProvider {
   buffer: String
@@ -20,15 +21,13 @@ impl DataProvider for FileProvider {
 }
 
 impl FileProvider {
-  pub fn new<'a>(mut file: File) -> FileProvider {
+  pub fn new(mut file: File) -> io::Result<FileProvider> {
     let mut buffer: Vec<u8> = Vec::new();
-    let _ = file.read_to_end(&mut buffer);
+    file.read_to_end(&mut buffer)?;
 
-    let buffer = String::from_utf8(buffer).unwrap();
+    let buffer = String::from_utf8(buffer)
+      .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
-    FileProvider{
-      buffer
-    }
-
+    Ok(FileProvider { buffer })
   }
 }

--- a/src/data_provider/implementations/stdin_provider.rs
+++ b/src/data_provider/implementations/stdin_provider.rs
@@ -1,11 +1,15 @@
 use std::io;
-use std::io::{Lines, Read, Stdin, StdinLock};
 use crate::data_provider::data_provider::DataProvider;
 
 pub struct StdinProvider;
 impl DataProvider for StdinProvider {
   fn read(&self) -> Box<dyn Iterator<Item=String>> {
-    Box::new(io::stdin().lines().map(|s| s.unwrap()))
+    Box::new(io::stdin().lines().map(|line| {
+      line.unwrap_or_else(|e| {
+        eprintln!("Error: failed to read from stdin: {e}");
+        std::process::exit(1);
+      })
+    }))
   }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,16 @@ struct ParsedArgs {
     help: bool,
 }
 
+fn require_value(args: &[String], i: usize, flag: &str) -> String {
+    match args.get(i) {
+        Some(v) => v.clone(),
+        None => {
+            eprintln!("Error: {flag} requires a value");
+            std::process::exit(1);
+        }
+    }
+}
+
 fn parse_args(args: &[String]) -> ParsedArgs {
     let mut result = ParsedArgs {
         file_path: None,
@@ -79,24 +89,24 @@ fn parse_args(args: &[String]) -> ParsedArgs {
             result.help = true;
         } else if arg == "--input-file-path" {
             i += 1;
-            result.file_path = Some(args.get(i).expect("--input-file-path requires a value").clone());
+            result.file_path = Some(require_value(&args, i, "--input-file-path"));
         } else if let Some(v) = arg.strip_prefix("--input-file-path=") {
             result.file_path = Some(v.to_string());
         } else if arg == "--set" {
             i += 1;
-            result.set_args.push(args.get(i).expect("--set requires a value").clone());
+            result.set_args.push(require_value(&args, i, "--set"));
         } else if let Some(v) = arg.strip_prefix("--set=") {
             result.set_args.push(v.to_string());
         } else if let Some(v) = arg.strip_prefix("--get=") {
             result.get_path = Some(v.to_string());
         } else if arg == "--get" {
             i += 1;
-            result.get_path = Some(args.get(i).expect("--get requires a value").clone());
+            result.get_path = Some(require_value(&args, i, "--get"));
         } else if let Some(v) = arg.strip_prefix("--type=") {
             result.type_path = Some(v.to_string());
         } else if arg == "--type" {
             i += 1;
-            result.type_path = Some(args.get(i).expect("--type requires a value").clone());
+            result.type_path = Some(require_value(&args, i, "--type"));
         } else if !arg.starts_with('-') {
             result.file_path = Some(arg.clone());
         } else {
@@ -136,7 +146,10 @@ fn main() {
     let time = Instant::now();
     let provider = open_provider(parsed.file_path.as_deref());
     let buffer = provider.read();
-    let mut file = ConfigFile::from(buffer);
+    let mut file = ConfigFile::try_from(buffer).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    });
 
     if let Some(path_str) = parsed.get_path {
         let path = parse_config_path(&path_str);
@@ -251,7 +264,11 @@ fn open_provider(file_path: Option<&str>) -> Box<dyn DataProvider> {
                 eprintln!("Error: cannot open '{path}': {e}");
                 std::process::exit(1);
             });
-            Box::new(FileProvider::new(file))
+            let provider = FileProvider::new(file).unwrap_or_else(|e| {
+                eprintln!("Error: cannot read '{path}': {e}");
+                std::process::exit(1);
+            });
+            Box::new(provider)
         },
         None => Box::new(StdinProvider::new()),
     }


### PR DESCRIPTION
## Summary
- Malformed config lines (missing `{` for subtrees, missing `:`/`<` separators for arrays), non-UTF-8 input files, stdin read failures, and missing CLI flag values (`--set`, `--get`, `--type`, `--input-file-path`) previously crashed the process with a raw panic/backtrace.
- These now surface as a clean `Error: ...` message on stderr with exit code 1, consistent with the CLI's existing error-handling convention.
- Also bumps package version to 0.1.1.

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — all 34 existing tests pass
- [x] Manually verified each new error path (malformed tree/array header, missing flag value, missing file, non-UTF-8 file, valid round-trip still works)